### PR TITLE
Implement BinProcess::consume_events

### DIFF
--- a/cooldb/src/main.rs
+++ b/cooldb/src/main.rs
@@ -74,5 +74,7 @@ pub fn init_tracing(format: LogFormat) -> WorkerGuard {
 async fn db_logic(mut trigger_shutdown_rx: watch::Receiver<bool>) {
     tracing::info!("accepting inbound connections");
 
+    tracing::info!("some functionality occurs");
+
     trigger_shutdown_rx.changed().await.unwrap();
 }

--- a/tokio-bin-process/src/event_matcher.rs
+++ b/tokio-bin-process/src/event_matcher.rs
@@ -10,7 +10,7 @@ pub struct Events {
 }
 
 impl Events {
-    pub fn contains(&self, matcher: &EventMatcher) {
+    pub fn assert_contains(&self, matcher: &EventMatcher) {
         if !self.events.iter().any(|e| matcher.matches(e)) {
             panic!(
                 "An event with {matcher:?} was not found in the list of events:\n{}",
@@ -20,7 +20,7 @@ impl Events {
     }
 
     #[allow(dead_code)]
-    fn contains_in_order(&self, _matchers: &[EventMatcher]) {
+    fn assert_contains_in_order(&self, _matchers: &[EventMatcher]) {
         todo!()
     }
 }


### PR DESCRIPTION
We dont actually need consume_events in shotover yet, but it will certainly be helpful one day and I wanted to flesh out the API a bit more before I give my talk on tokio-bin-process.

The use case for consume_events is demonstrated in `cooldb/tests/test.rs`, it should be used as the most common way to assert that an `info` level (or lower) event occurred that indicates some internal functionality or state.