### PR TITLE
Arbitrary profiles

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ async fn cooldb_process() -> BinProcess {
             // so configure the application to produce that.
             "--log-format", "json"
         ],
+        None
     )
     .await;
 

--- a/tokio-bin-process/src/lib.rs
+++ b/tokio-bin-process/src/lib.rs
@@ -24,6 +24,7 @@
 //!             // so configure the application to produce that
 //!             "--log-format", "json"
 //!         ],
+//!         None
 //!     )
 //!     .await;
 //!


### PR DESCRIPTION
The state of cargo's PROFILE env var is really unfortunate.
No matter what profile is used the value always maps to debug or release.
If it werent for this we could entertain the idea of just relying on the PROFILE we are running in to set the profile to build the binary crate with.
Instead we need to provide some way for the user to set the profile they need.
At the same time I think the automatic profile selection is still useful even if it downgrades to debug/release.

So I propose we provide an Option<&str> to configure the profile so that we can fallback to automatic selection when None is provided.