### PR TITLE
Fix error detection during bin startup (breaking change)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ async fn cooldb_process() -> BinProcess {
                 .with_level(Level::Info)
                 .with_target("cooldb")
                 .with_message("accepting inbound connections"),
+            &[]
         ),
     )
     .await

--- a/tokio-bin-process/src/lib.rs
+++ b/tokio-bin-process/src/lib.rs
@@ -47,6 +47,7 @@
 //!                 .with_level(Level::Info)
 //!                 .with_target("cooldb")
 //!                 .with_message("accepting inbound connections"),
+//!             &[]
 //!         ),
 //!     )
 //!     .await

--- a/tokio-bin-process/src/process.rs
+++ b/tokio-bin-process/src/process.rs
@@ -303,12 +303,17 @@ impl BinProcess {
 
     /// Waits for the `ready` `EventMatcher` to match on an incoming event.
     /// All events that were encountered while waiting are returned.
-    pub async fn wait_for(&mut self, ready: &EventMatcher) -> Events {
+    pub async fn wait_for(
+        &mut self,
+        ready: &EventMatcher,
+        expected_errors_and_warnings: &[EventMatcher],
+    ) -> Events {
         let mut events = vec![];
         while let Some(event) = self.event_rx.recv().await {
             let ready_match = ready.matches(&event);
             events.push(event);
             if ready_match {
+                BinProcess::assert_no_errors_or_warnings(&events, expected_errors_and_warnings);
                 return Events { events };
             }
         }

--- a/tokio-bin-process/tests/test.rs
+++ b/tokio-bin-process/tests/test.rs
@@ -45,8 +45,13 @@ async fn test_cooldb_by_crate_name_bench_profile() {
 }
 
 async fn cooldb(profile: Option<&'static str>) -> BinProcess {
-    let mut cooldb =
-        BinProcess::start_crate_name("cooldb", "cooldb", &["--log-format", "json"], profile).await;
+    let mut cooldb = BinProcess::start_crate_name(
+        "cooldb",
+        "cooldb",
+        &["--log-format", "json", "--mode", "standard"],
+        profile,
+    )
+    .await;
 
     timeout(
         Duration::from_secs(30),
@@ -55,6 +60,7 @@ async fn cooldb(profile: Option<&'static str>) -> BinProcess {
                 .with_level(Level::Info)
                 .with_target("cooldb")
                 .with_message("accepting inbound connections"),
+            &[],
         ),
     )
     .await


### PR DESCRIPTION
Added tests for this functionality since its something that is clearly easy to miss.

Rather than just hardcoding to always fail on error/warn, I added an `expected_errors_and_warnings` arg to `wait_for` because users may want their application to emit warnings while starting up, e.g. for deprecated configuration.

Unfortunately this is a breaking change and will require a 0.3 release soon after our 0.2 release.