### PR TITLE
release tokio-bin-process 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-bin-process"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/tokio-bin-process/Cargo.toml
+++ b/tokio-bin-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-bin-process"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "run your application under a separate process with tokio tracing assertions when integration testing"

--- a/tokio-bin-process/single-crate-test/Cargo.lock
+++ b/tokio-bin-process/single-crate-test/Cargo.lock
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-bin-process"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",


### PR DESCRIPTION
Needs to be a breaking release as https://github.com/shotover/tokio-bin-process/pull/18 was breaking.