### PR TITLE
Release 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-bin-process"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/tokio-bin-process/Cargo.toml
+++ b/tokio-bin-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-bin-process"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "run your application under a separate process with tokio tracing assertions when integration testing"

--- a/tokio-bin-process/single-crate-test/Cargo.lock
+++ b/tokio-bin-process/single-crate-test/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-bin-process"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",


### PR DESCRIPTION
The only changes since 0.4 are:
https://github.com/shotover/tokio-bin-process/pull/27
https://github.com/shotover/tokio-bin-process/pull/26

And they are both nonbreaking changes so we can release this as 0.4.1