### PR TITLE
shutdown_and_then_consume_events API change

### DIFF
--- a/tokio-bin-process/single-crate-test/tests/test.rs
+++ b/tokio-bin-process/single-crate-test/tests/test.rs
@@ -15,7 +15,9 @@ async fn test_cooldb_binary_name() {
     // give the process time to setup its sigint/sigterm handler
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    process.shutdown_and_then_consume_events(&[]).await;
+    process
+        .shutdown_and_then_consume_events(Some(&[]), Some(&[]))
+        .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -30,5 +32,7 @@ async fn test_cooldb_binary() {
     // give the process time to setup its sigint/sigterm handler
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    process.shutdown_and_then_consume_events(&[]).await;
+    process
+        .shutdown_and_then_consume_events(Some(&[]), Some(&[]))
+        .await;
 }

--- a/tokio-bin-process/src/lib.rs
+++ b/tokio-bin-process/src/lib.rs
@@ -47,7 +47,8 @@
 //!                 .with_level(Level::Info)
 //!                 .with_target("cooldb")
 //!                 .with_message("accepting inbound connections"),
-//!             &[]
+//!             Some(&[]),
+//!             Some(&[]),
 //!         ),
 //!     )
 //!     .await
@@ -67,12 +68,13 @@
 //!     // but allow and expect a certain warning.
 //!     // A drop bomb ensures that the test will fail if we forget to call this method.
 //!     cooldb
-//!         .shutdown_and_then_consume_events(&[
+//!         .shutdown_and_then_consume_events(Some(&[
 //!             EventMatcher::new()
 //!                 .with_level(Level::Warn)
 //!                 .with_target("cooldb::internal")
 //!                 .with_message("The user did something silly that we want to warn about but is actually expected in this test case")
-//!         ])
+//!         ]),
+//!         Some(&[]))
 //!         .await;
 //! }
 //! ```

--- a/tokio-bin-process/tests/test.rs
+++ b/tokio-bin-process/tests/test.rs
@@ -11,17 +11,22 @@ async fn test_cooldb_by_binary_name() {
 
     // Assert that some functionality occured.
     // Use a timeout to prevent the test hanging if no events occur.
-    timeout(Duration::from_secs(5), cooldb.consume_events(1, &[]))
-        .await
-        .unwrap()
-        .assert_contains(
-            &EventMatcher::new()
-                .with_level(Level::Info)
-                .with_message("some functionality occurs"),
-        );
+    timeout(
+        Duration::from_secs(5),
+        cooldb.consume_events(1, Some(&[]), Some(&[])),
+    )
+    .await
+    .unwrap()
+    .assert_contains(
+        &EventMatcher::new()
+            .with_level(Level::Info)
+            .with_message("some functionality occurs"),
+    );
 
     // Shutdown cooldb asserting that it encountered no errors
-    cooldb.shutdown_and_then_consume_events(&[]).await;
+    cooldb
+        .shutdown_and_then_consume_events(Some(&[]), Some(&[]))
+        .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -31,17 +36,22 @@ async fn test_cooldb_by_binary_name_bench_profile() {
 
     // Assert that some functionality occured.
     // Use a timeout to prevent the test hanging if no events occur.
-    timeout(Duration::from_secs(5), cooldb.consume_events(1, &[]))
-        .await
-        .unwrap()
-        .assert_contains(
-            &EventMatcher::new()
-                .with_level(Level::Info)
-                .with_message("some functionality occurs"),
-        );
+    timeout(
+        Duration::from_secs(5),
+        cooldb.consume_events(1, Some(&[]), Some(&[])),
+    )
+    .await
+    .unwrap()
+    .assert_contains(
+        &EventMatcher::new()
+            .with_level(Level::Info)
+            .with_message("some functionality occurs"),
+    );
 
     // Shutdown cooldb asserting that it encountered no errors
-    cooldb.shutdown_and_then_consume_events(&[]).await;
+    cooldb
+        .shutdown_and_then_consume_events(Some(&[]), Some(&[]))
+        .await;
 }
 
 async fn cooldb(profile: Option<&'static str>) -> BinProcess {
@@ -60,7 +70,8 @@ async fn cooldb(profile: Option<&'static str>) -> BinProcess {
                 .with_level(Level::Info)
                 .with_target("cooldb")
                 .with_message("accepting inbound connections"),
-            &[],
+            Some(&[]),
+            Some(&[]),
         ),
     )
     .await


### PR DESCRIPTION
Changed the signature of `shutdown_and_then_consume_events` to allow for ignoring warnings or errors.

Happy for better suggestions regarding the API as long as functionality remains the same.  

```rust
pub async fn shutdown_and_then_consume_events(
    self,
    expected_errors: Option<&[EventMatcher]>,
    expected_warnings: Option<&[EventMatcher]>
) -> Events
```
