### PR TITLE
Update rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = [
     "cooldb",
     "integration-test"
 ]
+resolver = "2"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.71"
+channel = "1.75"
 components = [ "rustfmt", "clippy" ]

--- a/tokio-bin-process/src/event_matcher.rs
+++ b/tokio-bin-process/src/event_matcher.rs
@@ -1,5 +1,7 @@
 //! Structures for matching an [`Event`]
 
+use std::fmt::Display;
+
 use crate::event::{Event, Level};
 use itertools::Itertools;
 
@@ -22,6 +24,22 @@ impl Events {
     #[allow(dead_code)]
     fn assert_contains_in_order(&self, _matchers: &[EventMatcher]) {
         todo!()
+    }
+}
+
+impl Display for Events {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut first = true;
+        for event in &self.events {
+            if first {
+                write!(f, "{event}")?;
+            } else {
+                write!(f, "\n{event}")?;
+            }
+            first = false;
+        }
+
+        Ok(())
     }
 }
 

--- a/tokio-bin-process/src/process.rs
+++ b/tokio-bin-process/src/process.rs
@@ -257,17 +257,14 @@ impl BinProcess {
             format!("{log_name: <10}") // pads log_name up to 10 chars so that it lines up properly when included in log output.
         };
 
-        let mut child = Some(
-            Command::new(bin_path)
-                .args(binary_args)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .kill_on_drop(true)
-                .spawn()
-                .context(format!("Failed to run {bin_path:?}"))
-                .unwrap(),
-        )
-        .unwrap();
+        let mut child = Command::new(bin_path)
+            .args(binary_args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .context(format!("Failed to run {bin_path:?}"))
+            .unwrap();
 
         let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
         let stdout_reader = BufReader::new(child.stdout.take().unwrap()).lines();
@@ -382,8 +379,7 @@ impl BinProcess {
             .await;
 
         if status != 0 {
-            let events: String = events.events.iter().map(|x| format!("\n{x}")).collect();
-            panic!("The bin process exited with {status} but expected 0 exit code (Success).\nevents:{events}");
+            panic!("The bin process exited with {status} but expected 0 exit code (Success).\nevents:\n{events}");
         }
 
         events
@@ -399,8 +395,7 @@ impl BinProcess {
             .await;
 
         if status == 0 {
-            let events: String = events.events.iter().map(|x| format!("\n{x}")).collect();
-            panic!("The bin process exited with {status} but expected non 0 exit code (Failure).\nevents:{events}");
+            panic!("The bin process exited with {status} but expected non 0 exit code (Failure).\nevents:\n{events}");
         }
 
         events


### PR DESCRIPTION
and resolve warnings introduced since 1.71

The addition of `Display for Events` was to resolve the warning: https://rust-lang.github.io/rust-clippy/master/index.html#/format_collect