### PR TITLE
Add EventMatcher::with_message_regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +729,7 @@ dependencies = [
  "nix",
  "nu-ansi-term 0.50.0",
  "once_cell",
+ "regex-lite",
  "serde",
  "serde_json",
  "subprocess",

--- a/tokio-bin-process/Cargo.toml
+++ b/tokio-bin-process/Cargo.toml
@@ -21,6 +21,7 @@ itertools = "0.13.0"
 once_cell = "1.17.1"
 chrono = "0.4.24"
 cargo_metadata = "0.18.0"
+regex-lite = "0.1.6"
 
 [dev-dependencies]
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/tokio-bin-process/single-crate-test/Cargo.lock
+++ b/tokio-bin-process/single-crate-test/Cargo.lock
@@ -378,6 +378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +545,7 @@ dependencies = [
  "nix",
  "nu-ansi-term",
  "once_cell",
+ "regex-lite",
  "serde",
  "serde_json",
  "subprocess",


### PR DESCRIPTION
While working on https://github.com/shotover/shotover-proxy/pull/1762 we found need for more powerful string matching.
I think its important for the default matcher to not use regex, we dont want punctuation to be misinterpreted as regex special characters.
But allowing the user to opt into regex via a method with regex in the name seems appropriate and powerful.