### PR TITLE
Release 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-bin-process"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/tokio-bin-process/Cargo.toml
+++ b/tokio-bin-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-bin-process"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "run your application under a separate process with tokio tracing assertions when integration testing"

--- a/tokio-bin-process/single-crate-test/Cargo.lock
+++ b/tokio-bin-process/single-crate-test/Cargo.lock
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-bin-process"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",


### PR DESCRIPTION
Adding a variant to Count in https://github.com/shotover/tokio-bin-process/pull/41 is a breaking change (but wont be in the future due to `#[non_exhaustive]`, so this release needs to be breaking.